### PR TITLE
Adding pip install nussl to the evaluation page

### DIFF
--- a/book/basics/evaluation.ipynb
+++ b/book/basics/evaluation.ipynb
@@ -177,6 +177,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install nussl"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "tags": [
@@ -256,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding pip install to the evaluation.html page.
Build succeeds locally, page looks correct.