### PR TITLE
Correct possible typo: source to bin

### DIFF
--- a/book/approaches/deep/architectures.md
+++ b/book/approaches/deep/architectures.md
@@ -173,7 +173,7 @@ Deep Clustering maps each TF bin to a high-dimensional
 embedding space such that TF bins dominated by the same source
 are close and those dominated by different sources are far apart.
 We say that a TF bin is _dominated_ by some Source $S_i$ if most
-of the energy in that source is from $S_i$.
+of the energy in that bin is from $S_i$.
 
 Deep Clustering has the same basic network architecture as a
 Mask Inference network: spectrogram input, to batch norm, to a


### PR DESCRIPTION
It looks like this sentence is trying to say that the energy of a source within a *bin* determines source domination of that bin, rather than the energy of the *source*.

As is, "if most of the energy in that source is from [that source]" seems not to make sense, because *all* of the energy from a source would come from that source.